### PR TITLE
[#3]Feat: 찜하기 기능 구현

### DIFF
--- a/src/main/java/com/inno/coogle/controller/HeartController.java
+++ b/src/main/java/com/inno/coogle/controller/HeartController.java
@@ -1,0 +1,31 @@
+package com.inno.coogle.controller;
+
+import com.inno.coogle.global.common.response.ApiUtils;
+import com.inno.coogle.global.common.response.CommonResponse;
+import com.inno.coogle.global.error.exception.ErrorCode;
+import com.inno.coogle.global.error.exception.InvalidValueException;
+import com.inno.coogle.security.UserDetailsImpl;
+import com.inno.coogle.service.HeartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/likes")
+public class HeartController {
+    private final HeartService heartService;
+
+    @PostMapping("/{postId}")
+    public CommonResponse<?> hearts(@PathVariable Long postId,
+                                    @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new InvalidValueException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+        String username = userDetails.getUsername();
+        return ApiUtils.success(200, heartService.hearts(username, postId));
+    }
+}

--- a/src/main/java/com/inno/coogle/controller/PostController.java
+++ b/src/main/java/com/inno/coogle/controller/PostController.java
@@ -51,8 +51,12 @@ public class PostController {
 
     // 게시글 상세 조회
     @GetMapping("/{postId}")
-    public CommonResponse<?> getOnePost(@PathVariable Long postId) {
-        return ApiUtils.success(200, postService.getOnePost(postId));
+    public CommonResponse<?> getOnePost(@PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new InvalidValueException(ErrorCode.HANDLE_ACCESS_DENIED);
+        }
+        Member member = memberRepository.findMemberByUsername(userDetails.getUsername());
+        return ApiUtils.success(200, postService.getOnePost(postId, member));
     }
 
     // 게시글 수정

--- a/src/main/java/com/inno/coogle/domain/Heart.java
+++ b/src/main/java/com/inno/coogle/domain/Heart.java
@@ -1,0 +1,41 @@
+package com.inno.coogle.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Heart {
+
+    @Id
+    @Column(name = "heart_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Builder
+    public Heart(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+
+    public void confirmPost(Post post) {
+        this.post = post;
+        post.addHearts(this);
+    }
+}

--- a/src/main/java/com/inno/coogle/domain/Post.java
+++ b/src/main/java/com/inno/coogle/domain/Post.java
@@ -1,5 +1,6 @@
 package com.inno.coogle.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.inno.coogle.converter.StringListConverter;
 import com.inno.coogle.dto.post.PostRequestDto;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 @Entity
@@ -18,6 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 public class Post extends Timestamped{
     @Id
+    @Column(name = "post_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -31,13 +34,14 @@ public class Post extends Timestamped{
     @NotBlank
     private String contents;
 
-//    @Convert(converter = StringListConverter.class)
+    @NotBlank
     private String ingredientsList;
 
-//    @Convert(converter = StringListConverter.class)
+    @NotBlank
     private String tagList;
+
     @NotNull
-    private Long level;
+    private int level;
 
     @NotBlank
     private String foodType;
@@ -47,6 +51,12 @@ public class Post extends Timestamped{
 
     private String thumbnailUrl;
 
+    private int heartNum;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    @JsonIgnore
+    private List<Heart> hearts = new LinkedList<>();
+
     public Post(Member member, PostRequestDto postRequestDto) {
         this.member = member;
         this.title = postRequestDto.getPostTitle();
@@ -55,6 +65,7 @@ public class Post extends Timestamped{
         this.tagList = postRequestDto.getTagList().toString();
         this.level = postRequestDto.getLevel();
         this.foodType = postRequestDto.getFoodType();
+        this.heartNum = 0;
     }
 
     public void update(PostRequestDto postRequestDto) {
@@ -64,6 +75,18 @@ public class Post extends Timestamped{
         this.tagList = postRequestDto.getTagList().toString();
         this.level = postRequestDto.getLevel();
         this.foodType = postRequestDto.getFoodType();
+    }
+
+    public void addHearts(Heart heart) {
+        hearts.add(heart);
+    }
+
+    public void like() {
+        this.heartNum += 1;
+    }
+
+    public void dislike() {
+        this.heartNum -= 1;
     }
 
 }

--- a/src/main/java/com/inno/coogle/dto/heart/HeartResponseDto.java
+++ b/src/main/java/com/inno/coogle/dto/heart/HeartResponseDto.java
@@ -1,0 +1,13 @@
+package com.inno.coogle.dto.heart;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class HeartResponseDto {
+    private int heartNum;
+    private Boolean heartState;
+}

--- a/src/main/java/com/inno/coogle/dto/post/PostDetailResponseDto.java
+++ b/src/main/java/com/inno/coogle/dto/post/PostDetailResponseDto.java
@@ -17,15 +17,17 @@ public class PostDetailResponseDto {
     private String imageUrl;
     private String ingredientsList;
     private String tagList;
-    private Long level;
+    private int level;
     private String foodType;
+    private int heartNum;
+    private Boolean heartState;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime modifiedAt;
 
     @Builder
-    public PostDetailResponseDto(Post post) {
+    public PostDetailResponseDto(Post post, int heartNum, Boolean heartState) {
         this.postId = post.getId();
         this.nickname = post.getMember().getNickname();
         this.postTitle = post.getTitle();
@@ -37,5 +39,7 @@ public class PostDetailResponseDto {
         this.foodType = post.getFoodType();
         this.createdAt = post.getCreatedAt();
         this.modifiedAt = post.getModifiedAt();
+        this.heartNum = heartNum;
+        this.heartState =heartState;
     }
 }

--- a/src/main/java/com/inno/coogle/dto/post/PostRequestDto.java
+++ b/src/main/java/com/inno/coogle/dto/post/PostRequestDto.java
@@ -10,7 +10,7 @@ public class PostRequestDto {
     private String postContents;
     private List<String> ingredientsList;
     private List<String> tagList;
-    private Long level;
+    private int level;
     private String foodType;
 
 }

--- a/src/main/java/com/inno/coogle/repository/HeartRepository.java
+++ b/src/main/java/com/inno/coogle/repository/HeartRepository.java
@@ -1,0 +1,10 @@
+package com.inno.coogle.repository;
+
+import com.inno.coogle.domain.Heart;
+import com.inno.coogle.domain.Member;
+import com.inno.coogle.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HeartRepository extends JpaRepository<Heart, Long> {
+    Heart findByMemberAndPost(Member member, Post post);
+}

--- a/src/main/java/com/inno/coogle/service/HeartService.java
+++ b/src/main/java/com/inno/coogle/service/HeartService.java
@@ -1,0 +1,58 @@
+package com.inno.coogle.service;
+
+import com.inno.coogle.domain.Heart;
+import com.inno.coogle.domain.Member;
+import com.inno.coogle.domain.Post;
+import com.inno.coogle.dto.heart.HeartResponseDto;
+import com.inno.coogle.global.error.exception.ErrorCode;
+import com.inno.coogle.global.error.exception.InvalidValueException;
+import com.inno.coogle.repository.HeartRepository;
+import com.inno.coogle.repository.MemberRepository;
+import com.inno.coogle.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HeartService {
+    private final HeartRepository heartRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+
+
+    @Transactional
+    public HeartResponseDto hearts(String username, Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new InvalidValueException(ErrorCode.NOTFOUND_POST));
+        Member member = memberRepository.findMemberByUsername(username);
+
+        Boolean heartState;
+        Heart heart = heartRepository.findByMemberAndPost(member, post);
+
+        if (post.getHearts().contains(heart)) {
+            heartRepository.deleteById(heart.getId());
+            post.dislike();
+            post.getHearts().remove(heart);
+            heartState = false;
+        } else {
+            post.like();
+            heart = new Heart(member, post);
+            heartRepository.save(heart);
+            heart.confirmPost(post);
+            postRepository.save(post);
+            heartState = true;
+        }
+        return HeartResponseDto.builder()
+                .heartState(heartState)
+                .heartNum(post.getHeartNum())
+                .build();
+    }
+
+    public Boolean heartState(Post post, Member member) {
+        Heart heart = heartRepository.findByMemberAndPost(member, post);
+        return heart != null;
+    }
+}

--- a/src/main/java/com/inno/coogle/service/PostService.java
+++ b/src/main/java/com/inno/coogle/service/PostService.java
@@ -25,6 +25,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final ImageRepository imageRepository;
     private final AmazonS3Service amazonS3Service;
+    private final HeartService heartService;
 
     // 게시글 작성
     @Transactional
@@ -57,11 +58,13 @@ public class PostService {
 
     // 상세 게시글 조회
     @Transactional
-    public PostDetailResponseDto getOnePost(Long postId) {
+    public PostDetailResponseDto getOnePost(Long postId, Member member) {
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new InvalidValueException(ErrorCode.NOTFOUND_POST));
         return PostDetailResponseDto.builder()
                 .post(post)
+                .heartNum(post.getHeartNum())
+                .heartState(heartService.heartState(post, member))
                 .build();
     }
 


### PR DESCRIPTION
#3 
- 찜하기 기능을 구현하였습니다.
- response에 heartNum과 현재 유저의 heartState를 담았습니다.
- 찜하기 등록/ 취소, 찜 개수, 찜 상태 확인은 모두 상세 페이지에서 이뤄집니다. 따라서 현재 유저의 heartState를 확인하기 위해서는 로그인 상태여야 하기 때문에, 로그인한 유저만 상세 페이지 조회가 가능하도록 변경하였습니다.
- Post 엔티티의 level과 heartNum의 데이터타입을 Long 에서 int로 변경하였습니다. (ERD도 변경)